### PR TITLE
Update clusterSim.cpp - case of integer overflow

### DIFF
--- a/src/clusterSim.cpp
+++ b/src/clusterSim.cpp
@@ -161,7 +161,7 @@ extern "C" void   fng2(double * within , int * nwithin, double * between , int *
 	if ((*nwithin)*(*nbetween)==rowne)
 		wynik[0]=0;
 	else
-		wynik[0]=(2.0*s)/((*nwithin)*(*nbetween)-rowne)-1.0;
+		wynik[0]=(2.0*s)/((double)(*nwithin)*(*nbetween)-rowne)-1.0;
 	return;
 }
 


### PR DESCRIPTION
Please review the following case. If the result of nwithin*nbetween goes beyond integer range, casting to double is needed. Otherwise wynik variable gets a wrong value.

Example R code when this happens:

library(cluster)
library(clusterSim)
a = matrix(runif(1000000,0,1),1000,1000)
d = as.dist(a)
p = pam(d,5,diss=TRUE)
cl=p$clustering  
index.G2(d,cl) # index G2 beyond [-1,1]
